### PR TITLE
Change TF username to be unique

### DIFF
--- a/.github/workflows/abbey-grant-kit-generate-policy-input.yaml
+++ b/.github/workflows/abbey-grant-kit-generate-policy-input.yaml
@@ -29,12 +29,12 @@ jobs:
         id: init
         run: terraform init
         env:
-          TF_HTTP_USERNAME: quickstart
+          TF_HTTP_USERNAME: starter-kit-gcp-identity
           TF_HTTP_PASSWORD: ${{ secrets.ABBEY_TOKEN }}
 
       - name: Terraform Plan
         id: plan
         run: terraform plan -no-color -input=false -out=tfplan
         env:
-          TF_HTTP_USERNAME: quickstart
+          TF_HTTP_USERNAME: starter-kit-gcp-identity
           TF_HTTP_PASSWORD: ${{ secrets.ABBEY_TOKEN }}

--- a/.github/workflows/abbey-grant-kit-materialize.yaml
+++ b/.github/workflows/abbey-grant-kit-materialize.yaml
@@ -31,13 +31,13 @@ jobs:
         id: init
         run: terraform init
         env:
-          TF_HTTP_USERNAME: quickstart
+          TF_HTTP_USERNAME: starter-kit-gcp-identity
           TF_HTTP_PASSWORD: ${{ secrets.ABBEY_TOKEN }}
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve -input=false
         env:
-          TF_HTTP_USERNAME:   quickstart
+          TF_HTTP_USERNAME:   starter-kit-gcp-identity
           TF_HTTP_PASSWORD:   ${{ secrets.ABBEY_TOKEN }}
           TF_VAR_abbey_token: ${{ secrets.ABBEY_TOKEN }}


### PR DESCRIPTION
When a user goes through multiple quickstarts that require creds for different 3rd party services i.e. GCP, Azure - terraform will fail due to trying to access the resource from a different quickstart without the proper credentials set up.

This is caused by TF state being shared across all the quickstarts. We can fix this by making the http_username field unique

Linear:
https://linear.app/abbey-labs/issue/ABB-755/scope-terraform-state-by-quickstart-with-unique-http-username